### PR TITLE
feat: add Dependabot configuration in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # Maintain dependencies for the frontend
+  - package-ecosystem: "npm"
+    directory: "/tenant_frontend"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "abenteuerzeit"
+    labels:
+      - "dependencies"
+      - "automated pr"
+    allow:
+      - dependency-type: "all"
+
+  # Maintain dependencies for the server
+  - package-ecosystem: "npm"
+    directory: "/server"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "abenteuerzeit"
+    labels:
+      - "dependencies"
+      - "automated pr"
+    allow:
+      - dependency-type: "all"
+


### PR DESCRIPTION
+ Adds a `dependabot.yml` file to the directory;
+ Enables Dependabot to check for dependency updates in frontend and server directories daily. 
+ Set to open up to 10 pull requests in each directory when it finds outdated dependencies. 
+ PRs to be reviewed by me