### PR TITLE
docs: add Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+As Tenant Talk is currently in the early stages of development, we do not yet have version numbers. All updates and security patches will be applied to the current version of the project on the `development` branch.
+
+## Reporting a Vulnerability
+
+If you discover a vulnerability in Tenant Talk, we greatly appreciate your help in reporting it to us. We take all security issues seriously.
+
+To report a security issue, please create a new issue in our GitHub repository and label it as "security". Please provide as much information as possible about the vulnerability, including steps to reproduce, its potential impact, and its potential solution if you have one.
+
+We will review the reported vulnerabilities and will communicate our response and planned actions within 7 days. Please refrain from publicly disclosing the issue until we have had a chance to address it.
+
+If the reported issue is confirmed as a vulnerability, we will work to address it as quickly as possible and will release a security update. If the issue is not deemed to be a vulnerability, we will provide an explanation in the issue discussion.
+
+Thank you for helping us keep Tenant Talk safe for everyone.


### PR DESCRIPTION
Adds a Security Policy to the project. The policy outlines the project's approach to supported versions and provides instructions for reporting a vulnerability. As the project is in the early stages of development, the policy notes that all updates and security patches will be applied to the current version of the project on the `main` or `development` branch.