### PR TITLE
feat(github-action): trigger on dependabot PRs and package.json changes

### DIFF
--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -5,12 +5,14 @@ on:
     types: [closed]
     branches: [development]
     paths:
-      - '**/package-lock.json'
-      - '**/package.json'
+      - 'server/package-lock.json'
+      - 'tenant_frontend/package-lock.json'
+      - 'server/package.json'
+      - 'tenant_frontend/package.json'
 
 jobs:
   update-lockfile:
-    if: github.event.pull_request.merged == true && github.event.pull_request.user.type == 'User'
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
- Updated the GitHub Action to trigger when a pull request, initiated by either a user or a bot, is merged into the development branch.
- Expanded the action to also trigger when changes occur in either `package-lock.json` or `package.json` files located in `server` or `tenant_frontend` directories.
- Adjusted the action to create a unique branch for each run, using the commit hash of the HEAD commit.
- The action now labels the created pull requests as "automated pr".
- Refactored the action to use `npm update` followed by `npm install` to ensure all npm packages are updated.

BREAKING CHANGE: The action now also triggers on bot-initiated PR merges, such as those from Dependabot, and changes to `package.json` files. This might increase the number of runs significantly, depending on the project's activity.