### PR TITLE
feat(github-action): add deployment to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -1,0 +1,46 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - development
+    paths:
+      - 'tenant_frontend/**'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tenant_frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+          
+      - name: Cache Node.js modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          branch: gh-pages
+          folder: tenant_frontend/build
+          clean: true


### PR DESCRIPTION
- Created a new GitHub Action workflow to automatically deploy the frontend to GitHub Pages from the development branch.
- The workflow triggers on any push to the development branch that includes changes in the tenant_frontend directory or its subdirectories.
- The workflow includes steps to checkout the repository, install dependencies, build the application, and deploy to GitHub Pages.
- Used JamesIves/github-pages-deploy-action for the deployment step.

BREAKING CHANGE: Deployment is now handled automatically through this GitHub Action, manual deployment is no longer necessary.