### PR TITLE
fix(github-action): correct build path for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -42,5 +42,5 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           branch: gh-pages
-          folder: tenant_frontend/build
+          folder: build
           clean: true


### PR DESCRIPTION
- Updated the GitHub Action for deploying to GitHub Pages from the development branch.
- Corrected the path to the build folder in the deployment step. The working directory was already set to 'tenant_frontend', so the path to the build folder is now just 'build' instead of 'tenant_frontend/build'.
- The workflow still triggers on any push to the development branch that includes changes in the tenant_frontend directory or its subdirectories.

BREAKING CHANGE: The GitHub Action will now correctly deploy the contents of the build folder from the tenant_frontend directory to the gh-pages branch. Previous deployments may have been incomplete or incorrect due to